### PR TITLE
New pipeline mode - Export

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -4,8 +4,9 @@ defaults:
   - _self_
   - preprocess: default
   - train: default
+  - export: default
 # each mode is a pipeline mode
-# preprocess/train
+# preprocess/train/export
 # list of tasks available in mode specific config
 mode: preprocess
 

--- a/conf/export/default.yaml
+++ b/conf/export/default.yaml
@@ -1,0 +1,2 @@
+tasks:
+  - cvat_exporter

--- a/conf/paths/default.yaml
+++ b/conf/paths/default.yaml
@@ -15,6 +15,7 @@ log_dir: ${paths.root_dir}/logs/
 preprocess:
   csv_dir: ${paths.project_dir}/preprocess/data_csvs
   image_dir: ${paths.project_dir}/preprocess/images
+  label_dir: ${paths.project_dir}/preprocess/annotations
 
 # training output paths
 train:

--- a/conf/paths/default.yaml
+++ b/conf/paths/default.yaml
@@ -19,7 +19,7 @@ preprocess:
 # training output paths
 train:
   model_dir: ${paths.project_dir}/train/models
-  model_data_dir: ${paths.project_dir}/train/model_data
+  model_data_dir: ${paths.project_dir}/train/data
 
 # path to database
 db_path: ${paths.data_dir}/db/agir.db

--- a/conf/paths/default.yaml
+++ b/conf/paths/default.yaml
@@ -13,9 +13,8 @@ log_dir: ${paths.root_dir}/logs/
 
 # preprocess output paths
 preprocess:
-  csv_dir: ${paths.project_dir}/preprocess/data/data_csvs
-  image_dir: ${paths.project_dir}/preprocess/data/images
-  # model_data_dir: ${paths.project_dir}/preprocess/data/model_data
+  csv_dir: ${paths.project_dir}/preprocess/data_csvs
+  image_dir: ${paths.project_dir}/preprocess/images
 
 # training output paths
 train:
@@ -29,9 +28,6 @@ db_path: ${paths.data_dir}/db/agir.db
 secrets_dir: ${paths.root_dir}/secrets/
 
 lts_locations:
-  # - /Volumes/screberg/longterm_images
-  # - /Volumes/screberg/GROW_DATA
-  # - /Volumes/screberg/longterm_images2
   - /mnt/research-projects/s/screberg/longterm_images
   - /mnt/research-projects/s/screberg/GROW_DATA
   - /mnt/research-projects/s/screberg/longterm_images2

--- a/conf/paths/default.yaml
+++ b/conf/paths/default.yaml
@@ -15,11 +15,12 @@ log_dir: ${paths.root_dir}/logs/
 preprocess:
   csv_dir: ${paths.project_dir}/preprocess/data/data_csvs
   image_dir: ${paths.project_dir}/preprocess/data/images
-  model_data_dir: ${paths.project_dir}/preprocess/data/model_data
+  # model_data_dir: ${paths.project_dir}/preprocess/data/model_data
 
 # training output paths
 train:
-  output_dir: ${paths.project_dir}/train
+  model_dir: ${paths.project_dir}/train/models
+  model_data_dir: ${paths.project_dir}/train/model_data
 
 # path to database
 db_path: ${paths.data_dir}/db/agir.db
@@ -35,6 +36,4 @@ lts_locations:
   - /mnt/research-projects/s/screberg/GROW_DATA
   - /mnt/research-projects/s/screberg/longterm_images2
 
-lts_human_annotations:
-  # - /Volumes/screberg/longterm_images2/semifield-database/plant-detection/annotations/
-  - /mnt/research-projects/s/screberg/longterm_images2/semifield-database/plant-detection/annotations/
+lts_human_annotations: /mnt/research-projects/s/screberg/longterm_images2/semifield-database/plant-detection/annotations/

--- a/conf/train/default.yaml
+++ b/conf/train/default.yaml
@@ -16,10 +16,9 @@ validation_split: 0.2
 parallel: true
 parallel_workers: 16
 
-models_path: ${paths.train.output_dir}/models
-
+models_path: ${paths.train.model_dir}
 # path to data saved in ultralytics format and also has the train/val split information
-model_data: ${paths.preprocess.model_data_dir}
+model_data: ${paths.train.model_data_dir}
 
 # Model hyperparameters
 # patience: 50

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import hydra
 from omegaconf import DictConfig, OmegaConf
 from src.preprocess import main as preprocess
 from src.train import main as train
+from src.export import main as export
 
 sys.path.append("src")
 
@@ -12,7 +13,8 @@ log = logging.getLogger(__name__)
 
 MODE_REGISTRY = {
     "preprocess": preprocess,
-    "train": train
+    "train": train,
+    "export" : export
 }
 
 @hydra.main(version_base="1.2", config_path="conf", config_name="config")

--- a/src/export.py
+++ b/src/export.py
@@ -1,0 +1,24 @@
+from omegaconf import DictConfig
+import logging
+from src.exporting.cvat_exporter import main as cvat_exporter_main
+
+log = logging.getLogger(__name__)
+
+TASK_REGISTRY = {
+    "cvat_exporter": cvat_exporter_main,
+}
+
+def main(cfg: DictConfig):
+    """
+    Main entrypoint for export mode
+    - cvat_exporter
+    """
+    log.info(f"Tasks: {cfg.export.tasks}")
+
+    for task in cfg.export.tasks:
+        if task in TASK_REGISTRY:
+            log.info(f"Running export task: {task}")
+            TASK_REGISTRY[task](cfg)
+        else:
+            log.error(f"Task {task} not found in TASK_REGISTRY")
+            raise ValueError(f"Task {task} not found in TASK_REGISTRY")

--- a/src/exporting/cvat_exporter.py
+++ b/src/exporting/cvat_exporter.py
@@ -19,8 +19,7 @@ class CVATExporter:
         self.task_name = cfg.project.task_name
 
         # output directory for annotations
-        self.project_annotations_dir = Path(cfg.paths.root_dir, "projects", self.project_name, self.task_name, "annotations")
-        self.project_annotations_dir.mkdir(parents=True, exist_ok=True)
+        self.project_annotations_dir = Path(cfg.paths.preprocess.label_dir)
 
         # LTS path for annotations
         self.lts_annotations_dir = Path(cfg.paths.lts_human_annotations)
@@ -135,6 +134,9 @@ class CVATExporter:
         job = self.get_task_and_job()
         if job is None:
             return
+
+        # make the annotations dir after making sure that the project/task exists in cvat
+        self.project_annotations_dir.mkdir(parents=True, exist_ok=True)
 
         rq_id = self.export_annotations(job.id)
         download_url = self.poll_export_status(rq_id)

--- a/src/exporting/cvat_exporter.py
+++ b/src/exporting/cvat_exporter.py
@@ -1,0 +1,152 @@
+import logging
+import requests
+import time
+import zipfile
+import shutil
+from pathlib import Path
+from omegaconf import DictConfig
+from cvat_sdk import Client
+from src.utils.utils import read_secrets
+
+log = logging.getLogger(__name__)
+
+class CVATExporter:
+    def __init__(self, cfg: DictConfig) -> None:
+        self.cfg = cfg
+        self.cvat_secrets = read_secrets(cfg.secrets_path)['cvat']
+        self.dataset_format = cfg.cvat.dataset_format
+        self.project_name = cfg.project.name
+        self.task_name = cfg.project.task_name
+
+        # output directory for annotations
+        self.project_annotations_dir = Path(cfg.paths.root_dir, "projects", self.project_name, self.task_name, "annotations")
+        self.project_annotations_dir.mkdir(parents=True, exist_ok=True)
+
+        # LTS path for annotations
+        self.lts_annotations_dir = Path(cfg.paths.lts_human_annotations)
+
+        self.auth = (self.cvat_secrets['username'], self.cvat_secrets['password'])
+        self.api_url = self.cvat_secrets['url']
+
+    def login(self):
+        self.cvat_client = Client(self.api_url)
+        self.cvat_client.login([self.auth[0], self.auth[1]])
+
+    def get_task_and_job(self):
+        # find the project
+        projects = self.cvat_client.projects.list()
+        project = next((p for p in projects if p.name == self.project_name), None)
+        if not project:
+            log.warning(f"[Export Skipped] Project '{self.project_name}' not found.")
+            return None
+
+        # find the task within the project
+        tasks = self.cvat_client.tasks.list()
+        task = next((t for t in tasks if t.project_id == project.id and t.name == self.task_name), None)
+        if not task:
+            log.warning(f"[Export Skipped] Task '{self.task_name}' not found in project '{self.project_name}'.")
+            return None
+
+        # find the job for the task
+        jobs = self.cvat_client.jobs.list()
+        job = next((j for j in jobs if j.task_id == task.id), None)
+        if not job:
+            log.warning(f"[Export Skipped] No job found for task '{self.task_name}'.")
+            return None
+
+        return self.cvat_client.jobs.retrieve(job.id)
+
+    def export_annotations(self, job_id: int):
+        url = f"{self.api_url}/api/jobs/{job_id}/dataset/export"
+        params = {
+            "format": self.dataset_format,
+            "save_images": "false"
+        }
+
+        log.info(f"Initiating export for job ID: {job_id}")
+        response = requests.post(url, auth=self.auth, params=params)
+        response.raise_for_status()
+
+        rq_id = response.json().get("rq_id")
+        if not rq_id:
+            raise RuntimeError("Failed to get request ID from CVAT export API.")
+        return rq_id
+    
+    def export_annotations_lts(self, target_dir: Path):
+        source_dir = self.project_annotations_dir / "labels" / "train"
+        if not source_dir.exists():
+            log.warning(f"No annotations found in {source_dir}. Skipping export to LTS.")
+            return
+
+        target_dir.mkdir(parents=True, exist_ok=True)
+        label_files = list(source_dir.glob("*.txt"))
+
+        if not label_files:
+            log.warning(f"No .txt label files found in {source_dir}.")
+            return
+
+        for label_file in label_files:
+            shutil.copy2(label_file, target_dir / label_file.name)
+
+        log.info(f"Exported {len(label_files)} image annotation(s) to '{target_dir}'.")
+
+    def poll_export_status(self, rq_id: str, timeout=120) -> str:
+        url = f"{self.api_url}/api/requests/{rq_id}"
+
+        for _ in range(timeout // 3):
+            time.sleep(3)
+            response = requests.get(url, auth=self.auth)
+            response.raise_for_status()
+            status_data = response.json()
+            status = status_data["status"]
+            log.info(f"Export request {rq_id} status: {status}")
+
+            if status == "finished":
+                if "result_url" in status_data:
+                    return status_data["result_url"]
+                else:
+                    raise RuntimeError(f"Export finished but no result_url found: {status_data}")
+
+            elif status == "failed":
+                raise RuntimeError(f"Export failed: {status_data}")
+
+        raise TimeoutError("Timed out waiting for annotation export.")
+
+
+    def download_and_extract(self, download_url: str):
+        log.info(f"Downloading annotation zip from: {download_url}")
+        zip_response = requests.get(download_url, auth=self.auth)
+        zip_response.raise_for_status()
+
+        zip_path = self.project_annotations_dir / "annotations.zip"
+        with open(zip_path, "wb") as f:
+            f.write(zip_response.content)
+
+        # extract
+        log.info(f"Unzipping to {self.project_annotations_dir}")
+        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+            zip_ref.extractall(self.project_annotations_dir)
+
+        # delete zip
+        zip_path.unlink()
+        log.info(f"Deleted temporary zip: {zip_path}")
+
+    def run(self):
+        job = self.get_task_and_job()
+        if job is None:
+            return
+
+        rq_id = self.export_annotations(job.id)
+        download_url = self.poll_export_status(rq_id)
+        self.download_and_extract(download_url)
+        self.export_annotations_lts(self.lts_annotations_dir)
+
+def main(cfg: DictConfig) -> None:
+    log.info("Starting CVAT annotation export process")
+    exporter = CVATExporter(cfg)
+    exporter.login()
+    exporter.run()
+    log.info("Annotation export step completed (may have been skipped if project/task/job was missing)")
+
+if __name__ == "__main__":
+    main()

--- a/src/training/prepare_dataset.py
+++ b/src/training/prepare_dataset.py
@@ -25,9 +25,7 @@ class PrepareDataset:
         self.random_seed = self.cfg.train.random_seed
         self.validation_split = self.cfg.train.validation_split
 
-        timestamp_date = datetime.now().strftime("%Y-%m-%d")
-        timestamp_time = datetime.now().strftime("%H-%M-%S")
-        self.train_data_path = Path(self.cfg.train.model_data) / timestamp_date / timestamp_time
+        self.train_data_path = Path(self.cfg.train.model_data)
         os.makedirs(self.train_data_path, exist_ok=True)
 
         # Parallel processing configuration

--- a/src/training/train_model.py
+++ b/src/training/train_model.py
@@ -22,9 +22,9 @@ class TrainModel:
         self.cfg = cfg
         
         # Set up paths
-        self.data_path = find_most_recent_dataset_path(Path(self.cfg.train.model_data))
+        self.data_path = (Path(self.cfg.train.model_data))
         log.info(f"Using dataset at {self.data_path}")
-        self.output_dir = Path(self.cfg.train.models_path) / self.data_path.parent.name / self.data_path.name
+        self.output_dir = Path(self.cfg.train.models_path)
         os.makedirs(self.output_dir, exist_ok=True)
         
         # Create data.yaml
@@ -69,7 +69,7 @@ class TrainModel:
             device=0 if torch.cuda.is_available() else 'cpu',
             # device='cpu',
             project=str(self.output_dir),
-            name='run1',
+            name='run',
             save=True,
             # patience=self.cfg.train.patience,
             # lr0=self.cfg.train.lr,
@@ -78,7 +78,7 @@ class TrainModel:
         
         # Save the model
         model.export()
-        log.info(f"Model trained and saved to {self.output_dir}/run1")
+        log.info(f"Model trained and saved to {results.save_dir}")
         
         return results
         

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -75,18 +75,18 @@ def get_annotated_image_ids(lts_locations):
             continue
 
         # Go through all directories in the base path
-        for directory in [d for d in base_path.iterdir() if d.is_dir()]:
-            # Look for annotations as .txt files in this directory
-            txt_files = directory.glob("*.txt")
-            # Extract filenames without extension and add to image_ids
-            for txt_file in txt_files:
-                image_id = txt_file.stem  # Get filename without extension
-                if image_id in image_ids.keys():
-                    log.error(f"Found multiple annotations for {image_id}")
-                    raise ValueError(f"Found multiple annotations for {image_id}")
-                image_ids[image_id] = txt_file
-                    # image_ids.append(image_id)
-                    # full_paths.append(txt_file)
+        
+        # Look for annotations as .txt files in this directory
+        txt_files = base_path.glob("*.txt")
+        # Extract filenames without extension and add to image_ids
+        for txt_file in txt_files:
+            image_id = txt_file.stem  # Get filename without extension
+            if image_id in image_ids.keys():
+                log.error(f"Found multiple annotations for {image_id}")
+                raise ValueError(f"Found multiple annotations for {image_id}")
+            image_ids[image_id] = txt_file
+                # image_ids.append(image_id)
+                # full_paths.append(txt_file)
     
     log.info(f"Found {len(image_ids)} annotated image IDs")
     return image_ids

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -61,6 +61,10 @@ def get_annotated_image_ids(lts_locations):
     Returns:
         List[str]: image ids for images already annotated
     """
+    # Wraps string or path inside a list
+    if isinstance(lts_locations, (str, Path)):
+        lts_locations = [lts_locations]
+
     image_ids = {}
     # TODO: check data.yaml in each subdirectory to verify 3 classes
     # Check if base path exists
@@ -69,21 +73,18 @@ def get_annotated_image_ids(lts_locations):
         if not base_path.exists():
             log.warning(f"Base path does not exist: {base_path}")
             continue
+
         # Go through all directories in the base path
         for directory in [d for d in base_path.iterdir() if d.is_dir()]:
-            # Look for 'labels' subfolder
-            labels_dir = directory / "labels"
-            if labels_dir.exists() and labels_dir.is_dir():
-                # Use recursive glob to get all txt files in labels directory and its subfolders
-                txt_files = labels_dir.glob("**/*.txt")
-                # Extract filenames without extension and add to image_ids
-                for txt_file in txt_files:
-                    image_id = txt_file.stem  # Get filename without extension
-                    if image_id in image_ids.keys():
-                        log.error(f"Found multiple annotations for {image_id}")
-                        raise ValueError(f"Found multiple annotations for {image_id}")
-                    
-                    image_ids[image_id] = txt_file
+            # Look for annotations as .txt files in this directory
+            txt_files = directory.glob("*.txt")
+            # Extract filenames without extension and add to image_ids
+            for txt_file in txt_files:
+                image_id = txt_file.stem  # Get filename without extension
+                if image_id in image_ids.keys():
+                    log.error(f"Found multiple annotations for {image_id}")
+                    raise ValueError(f"Found multiple annotations for {image_id}")
+                image_ids[image_id] = txt_file
                     # image_ids.append(image_id)
                     # full_paths.append(txt_file)
     


### PR DESCRIPTION
- Can run ```python main.py mode=export``` to get job annotations of the given project/task name in config
- Also copies the *.txt files of the annotations to the lts directory
- Updated some parts of the train pipeline to remove date time structure
- Moved ```model_data``` folder from preprocess to train since it is made when we run the train mode
- Addresses #26 and ultimately #22 